### PR TITLE
W22 7pm 3 Profits Table Displays profits

### DIFF
--- a/frontend/src/fixtures/profitsFixtures.js
+++ b/frontend/src/fixtures/profitsFixtures.js
@@ -10,8 +10,8 @@ const profitsFixtures = {
         "totalWealth": 0,
         "avgCowHealth": 100
       },
-      "profit": 44,
-      "time": "2001-10-10T01:01:01"
+      "profit": 10,
+      "time": "2002-10-10T01:01:01"
     },
     {
       "id": 3,
@@ -22,8 +22,8 @@ const profitsFixtures = {
         "totalWealth": 0,
         "avgCowHealth": 100
       },
-      "profit": 44,
-      "time": "2001-10-10T01:01:01"
+      "profit": 20,
+      "time": "2003-10-10T01:01:01"
     },
     {
       "id": 4,
@@ -34,8 +34,8 @@ const profitsFixtures = {
         "totalWealth": 0,
         "avgCowHealth": 100
       },
-      "profit": 44,
-      "time": "2001-10-10T01:01:01"
+      "profit": 40,
+      "time": "2004-10-10T01:01:01"
     }
   ]
 }

--- a/frontend/src/fixtures/profitsFixtures.js
+++ b/frontend/src/fixtures/profitsFixtures.js
@@ -1,0 +1,42 @@
+const profitsFixtures = {
+    threeProfits:
+    [
+    {
+      "id": 2,
+      "userCommons": {
+        "id": 1,
+        "commonsId": 1,
+        "userId": 1,
+        "totalWealth": 0,
+        "avgCowHealth": 100
+      },
+      "profit": 44,
+      "time": "2001-10-10T01:01:01"
+    },
+    {
+      "id": 3,
+      "userCommons": {
+        "id": 1,
+        "commonsId": 1,
+        "userId": 1,
+        "totalWealth": 0,
+        "avgCowHealth": 100
+      },
+      "profit": 44,
+      "time": "2001-10-10T01:01:01"
+    },
+    {
+      "id": 4,
+      "userCommons": {
+        "id": 1,
+        "commonsId": 1,
+        "userId": 1,
+        "totalWealth": 0,
+        "avgCowHealth": 100
+      },
+      "profit": 44,
+      "time": "2001-10-10T01:01:01"
+    }
+  ]
+}
+export default profitsFixtures;

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -11,7 +11,7 @@ const Profits = ({userCommons}) => {
     const { data: profitsData, error: profitsError, status: profitsStatus } =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
-      [`/api/profits/all/commons?userCommonsId=1`],
+      [`/api/profits/all/commons?userCommonsId=${userCommons}`],
       { method: "GET", url: `/api/profits/all/commons/`,
           params: {
               userCommonsId: userCommons?.id

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -3,12 +3,6 @@ import { Card } from "react-bootstrap";
 import ProfitsTable from "main/components/Commons/ProfitsTable"
 import { useBackend } from "main/utils/useBackend";
 
-const dummyData = [
-    { id: 1, profit: 10, date: "2021-03-05" },
-    { id: 2, profit: 11, date: "2021-03-06" },
-    { id: 3, profit: 10, date: "2021-03-07" },
-    { id: 4, profit: 8, date: "2021-03-08" }
-];
 
 
 // add parameters 

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -3,26 +3,27 @@ import { Card } from "react-bootstrap";
 import ProfitsTable from "main/components/Commons/ProfitsTable"
 import { useBackend } from "main/utils/useBackend";
 
-// const dummyData = [
-//     { id: 1, profit: 10, date: "2021-03-05" },
-//     { id: 2, profit: 11, date: "2021-03-06" },
-//     { id: 3, profit: 10, date: "2021-03-07" },
-//     { id: 4, profit: 8, date: "2021-03-08" }
-// ];
+const dummyData = [
+    { id: 1, profit: 10, date: "2021-03-05" },
+    { id: 2, profit: 11, date: "2021-03-06" },
+    { id: 3, profit: 10, date: "2021-03-07" },
+    { id: 4, profit: 8, date: "2021-03-08" }
+];
 
 
 // add parameters 
 const Profits = ({userCommons}) => {
 
-    const { data: profitsData, error: _error, status: _status } =
+    const { data: profitsData, error: profitsError, status: profitsStatus } =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
-      [`/api/profits/all/commons?userCommonsId=${userCommons}`],
-      { method: "GET", url: "/api/profits/all/commons",
+      [`/api/profits/all/commons?userCommonsId=1`],
+      { method: "GET", url: `/api/profits/all/commons/`,
           params: {
               userCommonsId: userCommons?.id
           }
-       }
+       },
+       []
     );
 
     return (

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -1,24 +1,37 @@
 import React from "react";
 import { Card } from "react-bootstrap";
 import ProfitsTable from "main/components/Commons/ProfitsTable"
+import { useBackend } from "main/utils/useBackend";
 
-const dummyData = [
-    { id: 1, profit: 10, date: "2021-03-05" },
-    { id: 2, profit: 11, date: "2021-03-06" },
-    { id: 3, profit: 10, date: "2021-03-07" },
-    { id: 4, profit: 8, date: "2021-03-08" }
-];
+// const dummyData = [
+//     { id: 1, profit: 10, date: "2021-03-05" },
+//     { id: 2, profit: 11, date: "2021-03-06" },
+//     { id: 3, profit: 10, date: "2021-03-07" },
+//     { id: 4, profit: 8, date: "2021-03-08" }
+// ];
 
 
 // add parameters 
-const Profits = () => {
+const Profits = ({userCommons}) => {
+
+    const { data: profitsData, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/profits/all/commons?userCommonsId=${userCommons}`],
+      { method: "GET", url: "/api/profits/all/commons",
+          params: {
+              userCommonsId: userCommons?.id
+          }
+       }
+    );
+
     return (
         <Card>
             <Card.Header as="h5">Profits</Card.Header>
             <Card.Body>
                 {/* change 4am to admin-appointed time? And consider adding milk bottle as decoration */}
                 <Card.Title>You will earn profits from milking your cows everyday at 4am.</Card.Title>
-                <ProfitsTable profits={dummyData} />
+                <ProfitsTable profits={profitsData} />
             </Card.Body>
         </Card>
     );

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -2,18 +2,7 @@ import React from "react";
 import OurTable from "main/components/OurTable";
 
 export default function ProfitsTable({ profits }) {
-    //Not sure why this code doesn't work 
-    // const columns = [
-    //     {
-    //         Header: "Profit",
-    //         accessor: "profit",
-    //     },
-    //     {
-    //         Header: "Date",
-    //         accessor: "date",
-    //     }
-    // ];
-    // const memoizedColumns = React.useMemo(() => columns, [columns]);
+
 
     // Stryker disable ArrayDeclaration : [columns] and [students] are performance optimization; mutation preserves correctness
     const memoizedColumns = React.useMemo(() => 

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -24,7 +24,7 @@ export default function ProfitsTable({ profits }) {
             },
             {
                 Header: "Date",
-                accessor: "date",
+                accessor: "time",
             }
         ], 
     []);

--- a/frontend/src/stories/components/Commons/ProfitsTable.stories.js
+++ b/frontend/src/stories/components/Commons/ProfitsTable.stories.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import ProfitsTable from "main/components/Commons/ProfitsTable";
+import profitsFixtures from 'fixtures/profitsFixtures';
+
+export default {
+    title: 'components/Commons/ProfitsTable',
+    component: ProfitsTable
+};
+
+const Template = (args) => {
+    return (
+        <ProfitsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    profits: []
+};
+
+export const threeProfits = Template.bind({});
+threeProfits.args = {
+    profits: profitsFixtures.threeProfits
+};

--- a/frontend/src/tests/components/Commons/Profits.test.js
+++ b/frontend/src/tests/components/Commons/Profits.test.js
@@ -1,23 +1,53 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import Profits from "main/components/Commons/Profits"; 
 import userCommonsFixtures from "fixtures/userCommonsFixtures"; 
+import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import profitsFixtures from "fixtures/profitsFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+        commonsId: 1
+    })
+}));
+
 
 describe("Profits tests", () => {
 
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+
+
+
     test("renders without crashing", () => {
+
+        axiosMock.onGet("/api/profits/all/commons/").reply(200, profitsFixtures.threeProfits);
+    
         render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} />
-        );
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );        
     });
 
     test("table is filled by dummy data", () => {
         const { getByText, getByTestId } = render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} />
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} />
+                </MemoryRouter>
+            </QueryClientProvider>
         );
 
         const expectedHeaders = ["Profit", "Date" ];
-        const expectedFields = ["profit", "date" ];
+        const expectedFields = ["profit", "time" ];
         const testId = "ProfitsTable";
 
         expectedHeaders.forEach( (headerText) => {
@@ -31,13 +61,12 @@ describe("Profits tests", () => {
         });
 
         expect(getByTestId(`${testId}-cell-row-0-col-profit`)).toHaveTextContent(10);
-        expect(getByTestId(`${testId}-cell-row-1-col-profit`)).toHaveTextContent(11);
-        expect(getByTestId(`${testId}-cell-row-2-col-profit`)).toHaveTextContent(10);
-        expect(getByTestId(`${testId}-cell-row-3-col-profit`)).toHaveTextContent(8);
-        expect(getByTestId(`${testId}-cell-row-0-col-date`)).toHaveTextContent("2021-03-05");
-        expect(getByTestId(`${testId}-cell-row-1-col-date`)).toHaveTextContent("2021-03-06");
-        expect(getByTestId(`${testId}-cell-row-2-col-date`)).toHaveTextContent("2021-03-07");
-        expect(getByTestId(`${testId}-cell-row-3-col-date`)).toHaveTextContent("2021-03-08");
+        expect(getByTestId(`${testId}-cell-row-1-col-profit`)).toHaveTextContent(20);
+        expect(getByTestId(`${testId}-cell-row-2-col-profit`)).toHaveTextContent(40);
+        expect(getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("2002-10-10T01:01:01");
+        expect(getByTestId(`${testId}-cell-row-1-col-time`)).toHaveTextContent("2003-10-10T01:01:01");
+        expect(getByTestId(`${testId}-cell-row-2-col-time`)).toHaveTextContent("2004-10-10T01:01:01");
+        
     });
 
 });

--- a/frontend/src/tests/components/Commons/ProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/ProfitsTable.test.js
@@ -1,0 +1,61 @@
+
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import  profitsFixtures  from "fixtures/profitsFixtures";
+import ProfitsTable from "main/components/Commons/ProfitsTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+describe("CommonsTable tests", () => {
+  const queryClient = new QueryClient();
+  
+  test("renders without crashing for empty table", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProfitsTable profits={[]}/>
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+  });
+  
+  test("Has the expected column headers and content", () => {
+
+ 
+    const { getByText, getByTestId } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ProfitsTable profits={profitsFixtures.threeProfits} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["Profit", "Date"];
+    const expectedFields = ["profit", "time"];
+    const testId = "ProfitsTable";
+
+    expectedHeaders.forEach( (headerText) => {
+      const header = getByText(headerText);
+      expect(header).toBeInTheDocument();
+    } );
+
+    expectedFields.forEach((field) => {
+      const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(getByTestId(`${testId}-cell-row-0-col-profit`)).toHaveTextContent(10);
+    expect(getByTestId(`${testId}-cell-row-1-col-profit`)).toHaveTextContent(20);
+    expect(getByTestId(`${testId}-cell-row-2-col-profit`)).toHaveTextContent(40);
+    expect(getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent("2002-10-10T01:01:01");
+    expect(getByTestId(`${testId}-cell-row-1-col-time`)).toHaveTextContent("2003-10-10T01:01:01");
+    expect(getByTestId(`${testId}-cell-row-2-col-time`)).toHaveTextContent("2004-10-10T01:01:01");
+
+  });
+  
+});
+


### PR DESCRIPTION
# Overview

ProfitsTable no longer uses dummyData and displays profits. 
Added tests.
Added storybook.

# Issues Addressed

#49 

# Details

![image](https://user-images.githubusercontent.com/28098845/158002593-391ac1b6-5e8a-44ce-a253-a11c5d196788.png)

To test, you must add data manually through profits endpoint.
![image](https://user-images.githubusercontent.com/28098845/158002612-a05cb39f-7444-46bf-bcb1-8aef0a33e471.png)
